### PR TITLE
Better sign transaction UX

### DIFF
--- a/src/apps/cardano/layout/__init__.py
+++ b/src/apps/cardano/layout/__init__.py
@@ -3,52 +3,64 @@ from micropython import const
 from trezor import ui
 from trezor.messages import ButtonRequestType, MessageType
 from trezor.messages.ButtonRequest import ButtonRequest
-from trezor.ui.confirm import CONFIRMED, ConfirmDialog
+from trezor.ui.confirm import CONFIRMED, ConfirmDialog, HoldToConfirmDialog
 from trezor.ui.scroll import Scrollpage, animate_swipe, paginate
 from trezor.ui.text import Text
-from trezor.utils import chunks
+from trezor.utils import chunks, format_amount
+
+def format_coin_amount(amount, coin):
+    return "%s %s" % (format_amount(amount, 6), coin)
 
 
-async def confirm_with_pagination(
-    ctx, content, title: str, icon=ui.ICON_RESET, icon_color=ui.ORANGE
-):
-    first_page = const(0)
-    lines_per_page = const(4)
+async def confirm_sending(ctx, amount, to, coin):
+    to_lines = list(chunks(to, 17))
 
-    if isinstance(content, (list, tuple)):
-        lines = content
-    else:
-        lines = list(chunks(content, 17))
-    pages = list(chunks(lines, lines_per_page))
+    t1 = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
+    t1.normal("Confirm sending:")
+    t1.bold(format_coin_amount(amount, coin))
+    t1.normal("to:")
+    t1.bold(to_lines[0])
+    pages = [t1]
 
-    await ctx.call(ButtonRequest(code=ButtonRequestType.Other), MessageType.ButtonAck)
+    LINES_PER_PAGE = 4
+    if len(to_lines) > 1:
+        to_pages = list(chunks(to_lines[1:], LINES_PER_PAGE))
+        for page in to_pages:
+            t = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
+            for line in page:
+                t.bold(line)
+            pages.append(t)
 
-    paginator = paginate(
-        show_text_page, len(pages), first_page, pages, title, icon, icon_color
-    )
+    paginator = paginate(create_renderer(ConfirmDialog), len(pages), const(0), pages)
+    return await ctx.wait(paginator) == CONFIRMED
+    return True
+
+
+async def confirm_transaction(ctx, amount, fee, tx_size, network_name, coin):
+    t1 = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
+    t1.normal("Total amount:")
+    t1.bold(format_coin_amount(amount, coin))
+    t1.normal("including fee:")
+    t1.bold(format_coin_amount(fee, coin))
+
+    t2 = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
+    t2.normal("network name:")
+    t2.bold(network_name)
+    t2.normal("tx size: ")
+    t2.bold("%s bytes" % tx_size)
+
+    pages = [t1, t2]
+    paginator = paginate(create_renderer(HoldToConfirmDialog), len(pages), const(0), pages)
     return await ctx.wait(paginator) == CONFIRMED
 
 
-@ui.layout
-async def show_text_page(
-    page: int,
-    page_count: int,
-    pages: list,
-    title: str,
-    icon=ui.ICON_RESET,
-    icon_color=ui.ORANGE,
-):
-    if page_count == 1:
-        page = 0
-
-    lines = pages[page]
-    content = Text(title, icon, icon_color=icon_color)
-    content.mono(*lines)
-
-    content = Scrollpage(content, page, page_count)
-
-    if page + 1 >= page_count:
-        return await ConfirmDialog(content)
-    else:
-        content.render()
-        await animate_swipe()
+def create_renderer(confirmation_wrapper):
+    @ui.layout
+    async def page_renderer(page: int, page_count: int, pages: list):
+        content = Scrollpage(pages[page], page, page_count)
+        if page + 1 >= page_count:
+            return await confirmation_wrapper(content)
+        else:
+            content.render()
+            await animate_swipe()
+    return page_renderer

--- a/src/apps/cardano/layout/__init__.py
+++ b/src/apps/cardano/layout/__init__.py
@@ -36,20 +36,14 @@ async def confirm_sending(ctx, amount, to, coin):
     return True
 
 
-async def confirm_transaction(ctx, amount, fee, tx_size, network_name, coin):
+async def confirm_transaction(ctx, amount, fee, coin):
     t1 = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
     t1.normal("Total amount:")
     t1.bold(format_coin_amount(amount, coin))
     t1.normal("including fee:")
     t1.bold(format_coin_amount(fee, coin))
 
-    t2 = Text("Confirm transaction", ui.ICON_SEND, icon_color=ui.GREEN)
-    t2.normal("network name:")
-    t2.bold(network_name)
-    t2.normal("tx size: ")
-    t2.bold("%s bytes" % tx_size)
-
-    pages = [t1, t2]
+    pages = [t1]
     paginator = paginate(create_renderer(HoldToConfirmDialog), len(pages), const(0), pages)
     return await ctx.wait(paginator) == CONFIRMED
 
@@ -57,6 +51,10 @@ async def confirm_transaction(ctx, amount, fee, tx_size, network_name, coin):
 def create_renderer(confirmation_wrapper):
     @ui.layout
     async def page_renderer(page: int, page_count: int, pages: list):
+        # for som reason page index can be equal to page count
+        if page >= page_count:
+            page = page_count - 1
+
         content = Scrollpage(pages[page], page, page_count)
         if page + 1 >= page_count:
             return await confirmation_wrapper(content)

--- a/src/apps/cardano/sign_tx.py
+++ b/src/apps/cardano/sign_tx.py
@@ -56,8 +56,6 @@ async def show_tx(
         ctx,
         total_amount,
         fee,
-        tx_size,
-        network_name,
         "ADA"
     ):
         return False


### PR DESCRIPTION
Fixes #1 

I followed #1, but during the testing both of the screens contain basically the same information. The visualization is close to bitcoin, however we also show transaction size and network. Is it important for the user?

Please merge #3 first, then the `confirm_with_pagination` and `show_text_page` in layout can be removed completely. 